### PR TITLE
Add env-configurable speaker defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ A Next.js application that converts text scripts into podcast-style audio using 
 
 ```
 GOOGLE_API_KEY=your_google_api_key_here
+HOST_DEFAULT_VOICE=Kore
+GUEST_DEFAULT_VOICE=Puck
+HOST_DEFAULT_TONE="Speak in a clear, professional tone."
+GUEST_DEFAULT_TONE="Speak in a natural, conversational tone."
 ```
 
 ### Installation

--- a/src/app/api/generate-audio/route.ts
+++ b/src/app/api/generate-audio/route.ts
@@ -40,6 +40,12 @@ function createWavBuffer(pcmData: Buffer, sampleRate = 24000, channels = 1, bits
 // Initialize Google Gemini client for TTS
 const genAI = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY || '' });
 
+// Speaker defaults can be configured via environment variables
+const DEFAULT_HOST_VOICE = process.env.HOST_DEFAULT_VOICE || 'Kore';
+const DEFAULT_GUEST_VOICE = process.env.GUEST_DEFAULT_VOICE || 'Puck';
+const DEFAULT_HOST_TONE = process.env.HOST_DEFAULT_TONE || '';
+const DEFAULT_GUEST_TONE = process.env.GUEST_DEFAULT_TONE || '';
+
 // Helper function to get the last generated podcast's timestamp
 function getLastTimestamp(): string | null {
     try {
@@ -443,10 +449,10 @@ export async function POST(req: NextRequest) {
     try {
         const {
             text: enhancedScript,
-            hostTone = '',
-            guestTone = '',
-            geminiHostVoice = 'Kore',
-            geminiGuestVoice = 'Puck',
+            hostTone = DEFAULT_HOST_TONE,
+            guestTone = DEFAULT_GUEST_TONE,
+            geminiHostVoice = DEFAULT_HOST_VOICE,
+            geminiGuestVoice = DEFAULT_GUEST_VOICE,
             speakerVoices = [],
             speakerTones = [],
             numSpeakers = 2

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,14 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
+// Defaults can be overridden via environment variables
+const DEFAULT_HOST_VOICE = process.env.NEXT_PUBLIC_HOST_DEFAULT_VOICE || 'Kore';
+const DEFAULT_GUEST_VOICE = process.env.NEXT_PUBLIC_GUEST_DEFAULT_VOICE || 'Puck';
+const DEFAULT_HOST_TONE =
+  process.env.NEXT_PUBLIC_HOST_DEFAULT_TONE || 'Speak in a clear, professional tone.';
+const DEFAULT_GUEST_TONE =
+  process.env.NEXT_PUBLIC_GUEST_DEFAULT_TONE || 'Speak in a natural, conversational tone.';
+
 // Real Gemini TTS Voice Options (from official documentation)
 const GEMINI_VOICES = [
   { id: 'Zephyr', name: 'Zephyr (Bright)' },
@@ -46,12 +54,12 @@ export default function Home() {
   const [exampleShown, setExampleShown] = useState(false);
 
   // Shared settings for tone/style (used differently by each engine)
-  const [hostTone, setHostTone] = useState('Speak in a clear, professional tone.');
-  const [guestTone, setGuestTone] = useState('Speak in a natural, conversational tone.');
+  const [hostTone, setHostTone] = useState(DEFAULT_HOST_TONE);
+  const [guestTone, setGuestTone] = useState(DEFAULT_GUEST_TONE);
 
   // Gemini settings
-  const [geminiHostVoice, setGeminiHostVoice] = useState('Kore');
-  const [geminiGuestVoice, setGeminiGuestVoice] = useState('Puck');
+  const [geminiHostVoice, setGeminiHostVoice] = useState(DEFAULT_HOST_VOICE);
+  const [geminiGuestVoice, setGeminiGuestVoice] = useState(DEFAULT_GUEST_VOICE);
   const [extraSpeakers, setExtraSpeakers] = useState<{ voice: string; tone: string }[]>([]);
 
   // Number of speakers (1-4)


### PR DESCRIPTION
## Summary
- add environment variable support for default speaker voices and tones
- use these defaults in the API route and client page
- document new variables in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0f221e08322bf37bd5202e8299c