### PR TITLE
Add voice demo page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -230,9 +230,14 @@ Guest: That's a great point. With any powerful technology, we need thoughtful gu
       <div className="max-w-4xl mx-auto bg-white rounded-xl shadow-md overflow-hidden p-6">
         <div className="flex justify-between items-center mb-2">
           <h1 className="text-2xl font-bold text-gray-900">AI Podcast Generator</h1>
-          <a href="/chatbot" className="text-blue-600 hover:text-blue-800 visited:text-purple-600">
-            Try Chatbot
-          </a>
+          <div className="flex gap-4">
+            <a href="/voices" className="text-blue-600 hover:text-blue-800 visited:text-purple-600">
+              Voice Demos
+            </a>
+            <a href="/chatbot" className="text-blue-600 hover:text-blue-800 visited:text-purple-600">
+              Try Chatbot
+            </a>
+          </div>
         </div>
         <p className="text-gray-500 mb-6">Generate podcasts using Google&apos;s Gemini 2.5 Multi-Speaker TTS</p>
 

--- a/src/app/voices/page.tsx
+++ b/src/app/voices/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+const VOICES = [
+  'Achernar',
+  'Achird',
+  'Algenib',
+  'Algieba',
+  'Alnilam',
+  'Aoede',
+  'Autonoe',
+  'Callirrhoe',
+  'Charon',
+  'Despina',
+  'Enceladus',
+  'Erinome',
+  'Fenrir',
+  'Gacrux',
+  'Iapetus',
+  'Kore',
+  'Laomedeia',
+  'Leda',
+  'Orus',
+  'Puck',
+  'Pulcherrima',
+  'Rasalgethi',
+  'Sadachbia',
+  'Sadaltager',
+  'Schedar',
+  'Sulafat',
+  'Umbriel',
+  'Vindemiatrix',
+  'Zephyr',
+  'Zubenelgenubi',
+];
+
+export default function VoicesPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold mb-6">Voice Demos</h1>
+        <div className="grid gap-6 sm:grid-cols-2">
+          {VOICES.map((voice) => (
+            <div
+              key={voice}
+              className="bg-white shadow rounded-md p-4 flex flex-col"
+            >
+              <h2 className="text-lg font-semibold mb-2">{voice}</h2>
+              <audio
+                className="w-full"
+                controls
+                src={`/voices/${voice}.wav`}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a page at `/voices` with an audio player for each voice
- link to the demo page from the home page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e92408cc8322b3cd09276c3dbadf