### PR TITLE
Restrict speaker line parsing

### DIFF
--- a/src/app/api/process-script/route.ts
+++ b/src/app/api/process-script/route.ts
@@ -38,7 +38,7 @@ function parseScript(script: string): { speaker: string; text: string }[] {
 
     // Improved regex to handle various script formats
     // This handles formats like "Speaker: Text", "Speaker - Text", "[Speaker] Text", etc.
-    const speakerRegex = /^\s*(?:\*\*)?([^:[\]()]+)(?:\*\*)?\s*[:|-]\s*(.*)$/;
+    const speakerRegex = /^\s*(?:\*\*)?([^:[\]()]+)(?:\*\*)?\s*:\s*(.*)$/;
     // Alternative regex for bracket format: [Speaker] Text
     const bracketRegex = /^\s*\[([^\]]+)\]\s*(.*)$/;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,7 +63,7 @@ function parseScript(script: string): { speaker: string; text: string }[] {
   let currentSpeaker = '';
   let currentText = '';
 
-  const speakerRegex = /^\s*(?:\*\*)?([^:[\]()]+)(?:\*\*)?\s*[:|-]\s*(.*)$/;
+  const speakerRegex = /^\s*(?:\*\*)?([^:[\]()]+)(?:\*\*)?\s*:\s*(.*)$/;
   const bracketRegex = /^\s*\[([^\]]+)\]\s*(.*)$/;
 
   for (const line of lines) {


### PR DESCRIPTION
## Summary
- tighten speaker parsing regex to require a colon

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862394715f48322b79e1154f9e5def7